### PR TITLE
Fix premature token reuse causing 'No validaron las fechas del token' errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ El constructor `AfipServices` acepta un objeto que cumpla con la interfaz de `IC
 
 * `homo` Un booleano que determina el uso del entorno de homologación.
 * `cacheTokensPath` Path a un file dónde se cachearan los tokens obtenidos para no solicitarlos cada vez.
-* `tokensExpireInHours` La cantidad de horas en la que expirará el archivo de tokens cacheados.
+* `tokensExpireInHours` La cantidad de horas en la que expirará el archivo de tokens cacheados. Se usa como fallback: si la respuesta del WSAA incluye `expirationTime` (el caso normal), se respeta esa fecha real de expiración.
+* `tokensExpireMarginSeconds` Margen de seguridad en segundos para renovar el token *antes* de su expiración real y tolerar latencia y desfasajes de reloj contra los servidores de AFIP. Por defecto `600` (10 minutos).
 * `privateKeyContents` El contenido de la private key (no hace falta path en este caso)
 * `privateKeyPath` Path a la private key (al igual que antes podemos omitir el contenido)
 * `certContents` El contenido del certificado (no hace falta path en este caso)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Comunicación con los web services de AFIP utilizando nodejs.",
   "author": "Emilio Astarita",
   "licence": "MIT",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "packageManager": "pnpm@10.7.0",
   "engines": {
     "node": ">=6.0.0"

--- a/src/IConfigService.ts
+++ b/src/IConfigService.ts
@@ -4,6 +4,7 @@ export interface IConfigServiceBasics {
     homo: boolean;
     cacheTokensPath: string;
     tokensExpireInHours: number;
+    tokensExpireMarginSeconds?: number;
     privateKeyContents?: string;
     privateKeyPath?: string;
     certPath?: string;

--- a/src/lib/AfipSoap.ts
+++ b/src/lib/AfipSoap.ts
@@ -23,8 +23,11 @@ interface ICredential {
         sign: string;
     };
     created: string;
+    expires?: string;
     service: WsServicesNames;
 }
+
+const DEFAULT_TOKENS_EXPIRE_MARGIN_SECONDS = 600;
 
 type ICredentialsCache = {
     [K in WsServicesNames]?: ICredential;
@@ -286,6 +289,10 @@ export class AfipSoap {
         const loginCmsReturn = result.loginCmsReturn;
         const res = await parseXml<{
             loginTicketResponse: {
+                header?: {
+                    generationTime?: string;
+                    expirationTime?: string;
+                };
                 credentials: {
                     token: string;
                     sign: string;
@@ -294,16 +301,33 @@ export class AfipSoap {
         }>(loginCmsReturn);
         return {
             created: moment().format(),
+            expires: res.loginTicketResponse.header?.expirationTime,
             service,
             tokens: res.loginTicketResponse.credentials,
         };
     }
 
-    private isExpired(expireStr: string) {
-        const now = moment(new Date());
-        const expire = moment(expireStr);
-        const duration = moment.duration(now.diff(expire));
-        return duration.asHours() > this.config.tokensExpireInHours;
+    private isExpired(credential: ICredential): boolean {
+        const marginSeconds =
+            this.config.tokensExpireMarginSeconds ??
+            DEFAULT_TOKENS_EXPIRE_MARGIN_SECONDS;
+        // Prefer the real expiration granted by WSAA. Credentials cached by
+        // older versions only have `created`, so fall back to estimating from
+        // the configured lifetime.
+        const expire = credential.expires
+            ? moment(credential.expires)
+            : moment(credential.created).add(
+                  this.config.tokensExpireInHours,
+                  'hours'
+              );
+        if (!expire.isValid()) {
+            return true;
+        }
+        // Refresh ahead of the actual expiration: the token must survive
+        // request latency and any clock drift against AFIP servers.
+        return moment().isSameOrAfter(
+            expire.subtract(marginSeconds, 'seconds')
+        );
     }
 
     private async getTokensFromCache(
@@ -315,7 +339,7 @@ export class AfipSoap {
         const cacheService =
             typeof cache[service] === 'undefined' ? null : cache[service];
 
-        if (cacheService && !this.isExpired(cacheService.created)) {
+        if (cacheService && !this.isExpired(cacheService)) {
             return cacheService;
         }
         return null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,7 +54,7 @@ export function parseXml<T>(xml: string) {
 
 export async function readStringFromFile(
     path: string,
-    encoding = 'utf8'
+    encoding: BufferEncoding = 'utf8'
 ): Promise<string> {
     return (await readFile(path)).toString(encoding);
 }


### PR DESCRIPTION
## Problem

Intermittent `AfipResponseError` on service calls near the end of a cached token's lifetime:

```
ValidacionDeToken: No validaron las fechas del token GenTime, ExpTime, NowUTC
```

`isExpired()` estimated token validity as `created + tokensExpireInHours`, where `created` is stamped on the local clock **after** the WSAA login round trip. The real `ExpTime` is stamped by WSAA on **its** clock when the ticket is generated, so the cached estimate always outlives the real token by the login latency plus any clock drift — and the strict `>` comparison left zero safety margin. Requests issued in that window reuse a token the service has already expired (in the observed failure, `NowUTC == ExpTime` exactly).

## Fix

- Parse the `expirationTime` from the `loginTicketResponse` header and store it with the cached credential.
- `isExpired()` now checks against that real expiration minus a safety margin: new optional config `tokensExpireMarginSeconds` (default 600 = 10 minutes), so the token always survives request latency and clock drift.
- Backward compatible: cache files written by previous versions (no `expires` field) fall back to the old `created + tokensExpireInHours` estimate, with the margin applied. An unparsable `expires` value is treated as expired (forces a refresh).
- Also fixes the build under current `@types/node`: `readStringFromFile`'s `encoding` param is now typed `BufferEncoding`.
- README: documents `tokensExpireMarginSeconds` and clarifies `tokensExpireInHours` is now a fallback.

## Testing

- `pnpm build` clean; `npm pack --dry-run` OK.
- Exercised the compiled `isExpired` against: token inside/outside the margin window, expiry at exactly now, legacy cache entries (fresh and near end of life), garbage `expires` string, AFIP-style `-03:00` offset timestamps, and a custom margin override — all behave as expected.
- Verified the WSAA `loginTicketResponse` header XML parses into the shape the new code reads (with `explicitArray: false`).

Includes the version bump to 0.4.2.