### PR TITLE
Stop soap from leaking unhandled ECONNRESET rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,17 @@
     the returned promise is `soap`'s only error channel, and it does attach a
     rejection handler to it.
 
+### Changed
+
+- Raised the `soap` floor from `^1.1.11` to `^1.4.2`. Upstream dropped the
+  `async` from `Client._invoke` in 1.4.2, which removes the leak at the source;
+  the range previously allowed 1.4.1 and earlier, so consumers with an old
+  lockfile could still resolve an affected release. The resolved version is
+  unchanged (1.8.0) — only the floor moved.
+
 ### Added
 
 - Regression test suite (`pnpm test`) covering socket-level failures of both the
-  WSDL fetch and the SOAP call, with and without `tlsRequestOptions`.
+  WSDL fetch and the SOAP call, with and without `tlsRequestOptions`. The tests
+  assert the invariant directly against facturajs' own HttpClient, so they hold
+  whichever `soap` release ends up installed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## 0.4.3
+
+### Fixed
+
+- **No more `unhandledRejection` events when AFIP resets a connection.**
+
+    AFIP's front-ends intermittently reset TLS connections. When that happened
+    mid-invoice, applications saw bursts of process-level `unhandledRejection`
+    events carrying a raw `AxiosError: read ECONNRESET`, with no application
+    frames in the stack — even though the invoice itself went through, because
+    the very same error had already been delivered normally and retried.
+
+    The duplicate came from `soap`. Its `HttpClient.request()` reports a
+    transport failure twice: through the `callback` it was given, and through
+    the promise it returns. In `soap` releases up to 1.4.x, `Client._invoke` is
+    an `async` method whose last statement is
+    `return this.httpClient.request(...)`; the `async` wrapper creates a fresh
+    promise that adopts that rejection, and `Client._defineMethod` throws that
+    promise away without ever attaching a handler. The already-handled error
+    then resurfaced as an unhandled rejection.
+
+    facturajs' own `soap` HttpClient subclass now returns a promise that never
+    rejects — the error still travels through the callback, which is the channel
+    `soap` actually reads, so `getLastBillNumber`, `createBill` and friends keep
+    rejecting with the original `AxiosError` exactly as before. The subclass is
+    also installed unconditionally now; previously it was only used when TLS
+    request options were configured, so the fix would not have covered every
+    setup.
+
+    Streaming requests (`requestStream`) are deliberately left untouched: there
+    the returned promise is `soap`'s only error channel, and it does attach a
+    rejection handler to it.
+
+### Added
+
+- Regression test suite (`pnpm test`) covering socket-level failures of both the
+  WSDL fetch and the SOAP call, with and without `tlsRequestOptions`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 
 ### Changed
 
+- Corrected `engines.node` from `>=6.0.0` to `>=20.19.0`. The old value had been
+  stale for a long time and was never achievable: `soap` 1.8.0 requires Node
+  20.19+, `ntp-time-sync` requires 18+, and the published code targets ES2022.
+  This only makes the existing requirement visible — no runtime behaviour
+  changes, and nothing that worked before stops working.
 - Raised the `soap` floor from `^1.1.11` to `^1.4.2`. Upstream dropped the
   `async` from `Client._invoke` in 1.4.2, which removes the leak at the source;
   the range previously allowed 1.4.1 and earlier, so consumers with an old

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Comunicación con los web services de AFIP utilizando nodejs.",
   "author": "Emilio Astarita",
   "licence": "MIT",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packageManager": "pnpm@10.7.0",
   "engines": {
     "node": ">=6.0.0"
@@ -11,10 +11,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prettier": "prettier --write \"src/**/*.{md,json,ts}\"",
+    "prettier": "prettier --write \"{src,test}/**/*.{md,json,ts}\"",
     "clean": "rm -rf dist/*",
     "prepare": "pnpm prettier && pnpm clean && pnpm build",
     "build": "pnpm exec tsc",
+    "type:test": "pnpm exec tsc --project tsconfig.test.json",
+    "test": "pnpm build && pnpm type:test && node --test \"test/**/*.test.ts\"",
     "generate:types": "./scripts/generate-wsdl-types.sh",
     "type:dts": "tsc --emitDeclarationOnly --project tsconfig.build.json"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.4.3",
   "packageManager": "pnpm@10.7.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=20.19.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "moment": "^2.30.1",
     "node-forge": "^1.4.0",
     "ntp-time-sync": "^0.5.0",
-    "soap": "^1.1.11",
+    "soap": "^1.4.2",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       soap:
-        specifier: ^1.1.11
+        specifier: ^1.4.2
         version: 1.8.0(supports-color@8.1.1)
       xml2js:
         specifier: ^0.6.2
@@ -92,6 +92,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}

--- a/src/lib/AfipSoap.ts
+++ b/src/lib/AfipSoap.ts
@@ -34,6 +34,7 @@ type ICredentialsCache = {
 };
 
 type SoapRequestArgs = Parameters<soap.HttpClient['request']>;
+type SoapRequestResult = ReturnType<soap.HttpClient['request']>;
 type SoapRequestStreamArgs = Parameters<
     NonNullable<soap.HttpClient['requestStream']>
 >;
@@ -62,6 +63,29 @@ interface IAfipResponseError extends Error {
     code: string | number;
 }
 
+/**
+ * `soap`'s HttpClient reports a transport failure twice: once through the
+ * `callback` it was handed, and once through the promise it returns. Its own
+ * callers only read the callback and discard the promise — but in soap <=1.4.x
+ * `Client._invoke` is an `async` method whose last statement is
+ * `return this.httpClient.request(...)`. The `async` wrapper makes a fresh
+ * promise adopt that rejection, and `Client._defineMethod` throws it away, so
+ * the already-handled error resurfaces as a process-level `unhandledRejection`.
+ * AFIP resets connections often enough for this to be a daily occurrence in
+ * production.
+ *
+ * The callback is the channel soap actually reads, so the returned promise can
+ * safely be neutralised: keep the fulfilled response, drop the rejection.
+ */
+function withoutFloatingRejection(
+    pending: SoapRequestResult
+): SoapRequestResult {
+    return pending.then(
+        (response) => response,
+        () => undefined
+    ) as SoapRequestResult;
+}
+
 class ConfiguredHttpClient extends soap.HttpClient {
     constructor(
         private readonly defaultRequestOptions: Record<string, unknown>,
@@ -77,13 +101,18 @@ class ConfiguredHttpClient extends soap.HttpClient {
         exheaders?: SoapRequestArgs[3],
         exoptions?: SoapRequestArgs[4],
         _caller?: unknown
-    ) {
-        return super.request(rurl, data, callback, exheaders, {
-            ...this.defaultRequestOptions,
-            ...exoptions,
-        });
+    ): SoapRequestResult {
+        return withoutFloatingRejection(
+            super.request(rurl, data, callback, exheaders, {
+                ...this.defaultRequestOptions,
+                ...exoptions,
+            })
+        );
     }
 
+    // Not neutralised on purpose: in streaming mode the returned promise is the
+    // only channel soap has for reporting errors, and `Client._invoke` does
+    // attach a rejection handler to it.
     requestStream(
         rurl: SoapRequestStreamArgs[0],
         data: SoapRequestStreamArgs[1],
@@ -262,11 +291,14 @@ export class AfipSoap {
 
         if (Object.keys(tlsRequestOptions).length > 0) {
             options.wsdl_options = tlsRequestOptions;
-            options.httpClient = new ConfiguredHttpClient(
-                tlsRequestOptions,
-                options
-            );
         }
+
+        // Always installed, even without TLS overrides: this client is also what
+        // keeps soap from leaking unhandled rejections.
+        options.httpClient = new ConfiguredHttpClient(
+            tlsRequestOptions,
+            options
+        );
 
         return soap.createClientAsync(url, options);
     }

--- a/test/helpers/afip.ts
+++ b/test/helpers/afip.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { AgentOptions } from 'https';
+import type * as soap from 'soap';
+
+import { AfipServices } from '../../dist/AfipServices.js';
+import type { AfipSoap } from '../../dist/lib/AfipSoap.js';
+import type { IConfigService } from '../../dist/IConfigService.js';
+import type { FakeAfip } from './server.ts';
+
+/**
+ * `AfipSoap` hardcodes AFIP's hostnames and keeps its soap plumbing private.
+ * Tests need to point it at a throwaway server and get hold of the soap client
+ * it builds, so these describe the shape we deliberately reach into.
+ */
+interface AfipSoapInternals {
+    urls: {
+        homo: { login: string; service: string };
+        prod: { login: string; service: string };
+    };
+    getSoapClient(serviceName: string): Promise<soap.Client>;
+}
+
+interface AfipServicesInternals {
+    afipSoap: AfipSoap;
+}
+
+export interface TestClientOptions {
+    /** Mirrors the two ways a consumer can end up with or without a custom agent. */
+    tlsRequestOptions?: AgentOptions;
+    useLegacyTls?: boolean;
+}
+
+/**
+ * soap keeps a process-wide WSDL cache keyed by URL, so every test client gets
+ * its own URL — otherwise a test that wants the WSDL fetch to fail would be
+ * served from the cache of an earlier test.
+ */
+let clientSeq = 0;
+
+export interface TestClient {
+    services: AfipServices;
+    soapInternals: AfipSoapInternals;
+    serviceUrl: string;
+}
+
+/**
+ * Builds an `AfipServices` wired to `server`, with WSAA credentials already in
+ * the token cache so no login (and therefore no NTP round-trip or CMS signing)
+ * happens during the test.
+ */
+export function createTestClient(
+    server: FakeAfip,
+    options: TestClientOptions = {}
+): TestClient {
+    const cacheTokensPath = join(
+        mkdtempSync(join(tmpdir(), 'facturajs-test-')),
+        'tokens.json'
+    );
+    writeFileSync(
+        cacheTokensPath,
+        JSON.stringify({
+            wsfe: {
+                tokens: { token: 'test-token', sign: 'test-sign' },
+                created: new Date().toISOString(),
+                expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+                service: 'wsfe',
+            },
+        })
+    );
+
+    const config = {
+        homo: true,
+        cacheTokensPath,
+        tokensExpireInHours: 12,
+        // Never used: the token cache above short-circuits the WSAA login.
+        certContents: server.tls.cert,
+        privateKeyContents: server.tls.key,
+        ...(options.useLegacyTls === undefined
+            ? {}
+            : { useLegacyTls: options.useLegacyTls }),
+        ...(options.tlsRequestOptions === undefined
+            ? {}
+            : { tlsRequestOptions: options.tlsRequestOptions }),
+    } as IConfigService;
+
+    const services = new AfipServices(config);
+    const soapInternals = (services as unknown as AfipServicesInternals)
+        .afipSoap as unknown as AfipSoapInternals;
+
+    const serviceUrl = `${server.baseUrl}/{name}/service.asmx?wsdl&client=${++clientSeq}`;
+    soapInternals.urls = {
+        homo: {
+            login: `${server.baseUrl}/ws/services/LoginCms?wsdl`,
+            service: serviceUrl,
+        },
+        prod: { login: '', service: '' },
+    };
+
+    return {
+        services,
+        soapInternals,
+        serviceUrl: serviceUrl.replace('{name}', 'wsfev1'),
+    };
+}

--- a/test/helpers/server.ts
+++ b/test/helpers/server.ts
@@ -1,0 +1,101 @@
+import { createServer, Server } from 'https';
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Socket } from 'net';
+import { createSelfSignedPair } from './tls.ts';
+import type { SelfSignedPair } from './tls.ts';
+import { buildWsdl, LAST_BILL_RESPONSE } from './wsdl.ts';
+
+export type ResponseMode = 'ok' | 'reset';
+
+export interface FakeAfip {
+    readonly baseUrl: string;
+    readonly tls: SelfSignedPair;
+    /** How the next SOAP POST (not the WSDL fetch) is answered. */
+    mode: ResponseMode;
+    /** How the WSDL fetch is answered. */
+    wsdlMode: ResponseMode;
+    close(): Promise<void>;
+}
+
+/**
+ * Sends a TCP RST rather than a clean FIN, so the peer sees `ECONNRESET` — the
+ * exact shape of failure AFIP's front-ends produce when they drop a connection.
+ * On a TLS server the writable side is the TLSSocket; the raw socket underneath
+ * is the one that can be reset.
+ */
+function hardReset(socket: Socket): void {
+    const raw = (socket as Socket & { _parent?: Socket })._parent ?? socket;
+    if (typeof raw.resetAndDestroy === 'function') {
+        raw.resetAndDestroy();
+        return;
+    }
+    socket.destroy();
+}
+
+export async function startFakeAfip(): Promise<FakeAfip> {
+    const tls = createSelfSignedPair();
+    const state: { mode: ResponseMode; wsdlMode: ResponseMode } = {
+        mode: 'ok',
+        wsdlMode: 'ok',
+    };
+
+    const server: Server = createServer(
+        { cert: tls.cert, key: tls.key },
+        (req: IncomingMessage, res: ServerResponse) => {
+            const isWsdl = (req.url ?? '').toLowerCase().includes('wsdl');
+            const mode = isWsdl ? state.wsdlMode : state.mode;
+
+            req.resume();
+            req.on('end', () => {
+                if (mode === 'reset') {
+                    if (res.socket) {
+                        hardReset(res.socket);
+                    }
+                    return;
+                }
+                res.writeHead(200, {
+                    'content-type': 'text/xml; charset=utf-8',
+                });
+                res.end(isWsdl ? buildWsdl(baseUrl()) : LAST_BILL_RESPONSE);
+            });
+        }
+    );
+
+    const address = () => {
+        const addr = server.address();
+        if (addr === null || typeof addr === 'string') {
+            throw new Error('server is not listening on a TCP port');
+        }
+        return addr;
+    };
+    const baseUrl = () => `https://127.0.0.1:${address().port}`;
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', resolve);
+    });
+
+    return {
+        get baseUrl() {
+            return baseUrl();
+        },
+        tls,
+        get mode() {
+            return state.mode;
+        },
+        set mode(value: ResponseMode) {
+            state.mode = value;
+        },
+        get wsdlMode() {
+            return state.wsdlMode;
+        },
+        set wsdlMode(value: ResponseMode) {
+            state.wsdlMode = value;
+        },
+        close() {
+            return new Promise<void>((resolve, reject) => {
+                server.closeAllConnections();
+                server.close((err) => (err ? reject(err) : resolve()));
+            });
+        },
+    };
+}

--- a/test/helpers/tls.ts
+++ b/test/helpers/tls.ts
@@ -1,0 +1,46 @@
+import { generateKeyPairSync } from 'crypto';
+import forge from 'node-forge';
+
+export interface SelfSignedPair {
+    cert: string;
+    key: string;
+}
+
+/**
+ * Self-signed certificate for the throwaway HTTPS servers the tests spin up.
+ * The key pair comes from node's crypto (much faster than forge's pure-JS RSA);
+ * forge only assembles the X.509 wrapper around it.
+ */
+export function createSelfSignedPair(): SelfSignedPair {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const cert = forge.pki.createCertificate();
+    cert.publicKey = forge.pki.publicKeyFromPem(publicKey);
+    cert.serialNumber = '01';
+    cert.validity.notBefore = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    cert.validity.notAfter = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    const attrs = [{ name: 'commonName', value: 'localhost' }];
+    cert.setSubject(attrs);
+    cert.setIssuer(attrs);
+    cert.setExtensions([
+        { name: 'basicConstraints', cA: true },
+        {
+            name: 'subjectAltName',
+            altNames: [
+                { type: 2, value: 'localhost' },
+                { type: 7, ip: '127.0.0.1' },
+            ],
+        },
+    ]);
+    cert.sign(
+        forge.pki.privateKeyFromPem(privateKey),
+        forge.md.sha256.create()
+    );
+
+    return { cert: forge.pki.certificateToPem(cert), key: privateKey };
+}

--- a/test/helpers/wsdl.ts
+++ b/test/helpers/wsdl.ts
@@ -1,0 +1,87 @@
+/**
+ * Trimmed-down stand-in for AFIP's wsfev1 WSDL: just enough of
+ * `FECompUltimoAutorizado` for soap to build a client and a request envelope.
+ */
+export function buildWsdl(baseUrl: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:tns="http://ar.gov.afip.dif.FEV1/"
+                  xmlns:s="http://www.w3.org/2001/XMLSchema"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  targetNamespace="http://ar.gov.afip.dif.FEV1/">
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://ar.gov.afip.dif.FEV1/">
+      <s:element name="FECompUltimoAutorizado">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth">
+              <s:complexType>
+                <s:sequence>
+                  <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string"/>
+                  <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string"/>
+                  <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long"/>
+                </s:sequence>
+              </s:complexType>
+            </s:element>
+            <s:element minOccurs="1" maxOccurs="1" name="PtoVta" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="CbteTipo" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FECompUltimoAutorizadoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FECompUltimoAutorizadoResult">
+              <s:complexType>
+                <s:sequence>
+                  <s:element minOccurs="1" maxOccurs="1" name="PtoVta" type="s:int"/>
+                  <s:element minOccurs="1" maxOccurs="1" name="CbteTipo" type="s:int"/>
+                  <s:element minOccurs="1" maxOccurs="1" name="CbteNro" type="s:int"/>
+                </s:sequence>
+              </s:complexType>
+            </s:element>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="FECompUltimoAutorizadoSoapIn">
+    <wsdl:part name="parameters" element="tns:FECompUltimoAutorizado"/>
+  </wsdl:message>
+  <wsdl:message name="FECompUltimoAutorizadoSoapOut">
+    <wsdl:part name="parameters" element="tns:FECompUltimoAutorizadoResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="ServiceSoap">
+    <wsdl:operation name="FECompUltimoAutorizado">
+      <wsdl:input message="tns:FECompUltimoAutorizadoSoapIn"/>
+      <wsdl:output message="tns:FECompUltimoAutorizadoSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="ServiceSoap" type="tns:ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="FECompUltimoAutorizado">
+      <soap:operation soapAction="http://ar.gov.afip.dif.FEV1/FECompUltimoAutorizado" style="document"/>
+      <wsdl:input><soap:body use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal"/></wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Service">
+    <wsdl:port name="ServiceSoap" binding="tns:ServiceSoap">
+      <soap:address location="${baseUrl}/wsfev1/service.asmx"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`;
+}
+
+export const LAST_BILL_RESPONSE = `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <FECompUltimoAutorizadoResponse xmlns="http://ar.gov.afip.dif.FEV1/">
+      <FECompUltimoAutorizadoResult>
+        <PtoVta>1</PtoVta>
+        <CbteTipo>6</CbteTipo>
+        <CbteNro>42</CbteNro>
+      </FECompUltimoAutorizadoResult>
+    </FECompUltimoAutorizadoResponse>
+  </soap:Body>
+</soap:Envelope>`;

--- a/test/unhandled-rejection.test.ts
+++ b/test/unhandled-rejection.test.ts
@@ -1,0 +1,255 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { globalAgent } from 'https';
+import type { SecureContextOptions } from 'tls';
+import type * as soap from 'soap';
+
+import { createTestClient } from './helpers/afip.ts';
+import type { TestClientOptions } from './helpers/afip.ts';
+import { startFakeAfip } from './helpers/server.ts';
+import type { FakeAfip } from './helpers/server.ts';
+
+interface NodeErrorLike {
+    code?: string;
+    message?: string;
+}
+
+function errorCode(error: unknown): string | undefined {
+    return (error as NodeErrorLike | null)?.code;
+}
+
+/**
+ * V8 only reports a rejection as unhandled once the microtask queue has been
+ * drained, so give the loop a couple of turns before looking.
+ */
+async function settleEventLoop(): Promise<void> {
+    for (let i = 0; i < 3; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+    }
+}
+
+async function collectUnhandledRejections(
+    body: () => Promise<void>
+): Promise<unknown[]> {
+    const seen: unknown[] = [];
+    const listener = (reason: unknown) => {
+        seen.push(reason);
+    };
+    process.on('unhandledRejection', listener);
+    try {
+        await body();
+        await settleEventLoop();
+    } finally {
+        process.off('unhandledRejection', listener);
+    }
+    return seen;
+}
+
+function describeRejections(reasons: unknown[]): string {
+    return reasons
+        .map((reason) => {
+            const err = reason as NodeErrorLike | null;
+            return `${err?.code ?? 'no-code'}: ${err?.message ?? String(reason)}`;
+        })
+        .join(', ');
+}
+
+describe('soap transport failures', () => {
+    let server: FakeAfip;
+    let restoreCa: SecureContextOptions['ca'];
+
+    before(async () => {
+        server = await startFakeAfip();
+        // Trust the throwaway certificate for the requests that go out through
+        // node's default agent (the "no tlsRequestOptions" configuration).
+        restoreCa = globalAgent.options.ca;
+        globalAgent.options.ca = server.tls.cert;
+    });
+
+    after(async () => {
+        globalAgent.options.ca = restoreCa;
+        await server.close();
+    });
+
+    const configurations: Array<[string, TestClientOptions]> = [
+        ['with tlsRequestOptions', { tlsRequestOptions: {} }],
+        ['without tlsRequestOptions', { useLegacyTls: false }],
+    ];
+
+    for (const [label, options] of configurations) {
+        describe(label, () => {
+            it('rejects with the transport error and leaks nothing when the SOAP call is reset', async () => {
+                const { services } = createTestClient(server, {
+                    ...options,
+                    tlsRequestOptions: options.tlsRequestOptions && {
+                        ...options.tlsRequestOptions,
+                        ca: server.tls.cert,
+                    },
+                });
+
+                let caught: unknown;
+                const leaked = await collectUnhandledRejections(async () => {
+                    server.wsdlMode = 'ok';
+                    server.mode = 'reset';
+                    try {
+                        await services.getLastBillNumber({
+                            Auth: { Cuit: 20111111112 },
+                            params: { PtoVta: 1, CbteTipo: 6 },
+                        });
+                    } catch (error) {
+                        caught = error;
+                    }
+                });
+
+                assert.ok(caught, 'the caller must still see the failure');
+                assert.equal(errorCode(caught), 'ECONNRESET');
+                assert.deepEqual(
+                    leaked,
+                    [],
+                    `unexpected unhandled rejections: ${describeRejections(leaked)}`
+                );
+            });
+
+            it('rejects with the transport error and leaks nothing when the WSDL fetch is reset', async () => {
+                const { services } = createTestClient(server, {
+                    ...options,
+                    tlsRequestOptions: options.tlsRequestOptions && {
+                        ...options.tlsRequestOptions,
+                        ca: server.tls.cert,
+                    },
+                });
+
+                let caught: unknown;
+                const leaked = await collectUnhandledRejections(async () => {
+                    server.wsdlMode = 'reset';
+                    server.mode = 'ok';
+                    try {
+                        await services.getLastBillNumber({
+                            Auth: { Cuit: 20111111112 },
+                            params: { PtoVta: 1, CbteTipo: 6 },
+                        });
+                    } catch (error) {
+                        caught = error;
+                    }
+                });
+
+                assert.ok(caught, 'the caller must still see the failure');
+                assert.equal(errorCode(caught), 'ECONNRESET');
+                assert.deepEqual(
+                    leaked,
+                    [],
+                    `unexpected unhandled rejections: ${describeRejections(leaked)}`
+                );
+            });
+
+            it('still resolves normally when nothing fails', async () => {
+                const { services } = createTestClient(server, {
+                    ...options,
+                    tlsRequestOptions: options.tlsRequestOptions && {
+                        ...options.tlsRequestOptions,
+                        ca: server.tls.cert,
+                    },
+                });
+
+                server.wsdlMode = 'ok';
+                server.mode = 'ok';
+                const result = await services.getLastBillNumber({
+                    Auth: { Cuit: 20111111112 },
+                    params: { PtoVta: 1, CbteTipo: 6 },
+                });
+
+                assert.equal(result.CbteNro, 42);
+            });
+
+            /**
+             * The actual regression. soap <= 1.4.x declares `Client._invoke` as
+             * an `async` method ending in `return this.httpClient.request(...)`,
+             * and `Client._defineMethod` discards what `_invoke` returns. The
+             * `async` wrapper adopts the rejection of the http client's promise,
+             * so a transport error that was already delivered through the
+             * callback resurfaces as a process-level `unhandledRejection`.
+             *
+             * Reproduced here directly against the http client facturajs
+             * installs, so the guarantee holds no matter which soap release is
+             * resolved: the promise we hand back must never reject.
+             */
+            it('survives a soap caller that discards the promise from an async wrapper', async () => {
+                const { soapInternals } = createTestClient(server, {
+                    ...options,
+                    tlsRequestOptions: options.tlsRequestOptions && {
+                        ...options.tlsRequestOptions,
+                        ca: server.tls.cert,
+                    },
+                });
+
+                server.wsdlMode = 'ok';
+                server.mode = 'ok';
+                const client = await soapInternals.getSoapClient('wsfev1');
+                const httpClient = (
+                    client as unknown as { httpClient: soap.HttpClient }
+                ).httpClient;
+                const endpoint = `${server.baseUrl}/wsfev1/service.asmx`;
+
+                let callbackError: unknown;
+                const leaked = await collectUnhandledRejections(async () => {
+                    server.mode = 'reset';
+                    await new Promise<void>((resolve) => {
+                        // Exactly soap <= 1.4.x's shape: an async function that
+                        // returns the http client's promise, called for its side
+                        // effects only.
+                        void (async () =>
+                            httpClient.request(
+                                endpoint,
+                                '<soap:Envelope/>',
+                                (error: unknown) => {
+                                    callbackError = error;
+                                    resolve();
+                                },
+                                {},
+                                {}
+                            ))();
+                    });
+                });
+
+                assert.ok(
+                    callbackError,
+                    'soap must still be told about the failure through the callback'
+                );
+                assert.equal(errorCode(callbackError), 'ECONNRESET');
+                assert.deepEqual(
+                    leaked,
+                    [],
+                    `unexpected unhandled rejections: ${describeRejections(leaked)}`
+                );
+            });
+
+            it('never rejects the promise it returns to soap', async () => {
+                const { soapInternals } = createTestClient(server, {
+                    ...options,
+                    tlsRequestOptions: options.tlsRequestOptions && {
+                        ...options.tlsRequestOptions,
+                        ca: server.tls.cert,
+                    },
+                });
+
+                server.wsdlMode = 'ok';
+                server.mode = 'ok';
+                const client = await soapInternals.getSoapClient('wsfev1');
+                const httpClient = (
+                    client as unknown as { httpClient: soap.HttpClient }
+                ).httpClient;
+
+                server.mode = 'reset';
+                await assert.doesNotReject(() =>
+                    httpClient.request(
+                        `${server.baseUrl}/wsfev1/service.asmx`,
+                        '<soap:Envelope/>',
+                        () => undefined,
+                        {},
+                        {}
+                    )
+                );
+            });
+        });
+    }
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "sourceMap": false,
+        "allowImportingTsExtensions": true,
+        "rootDir": "."
+    },
+    "include": ["test/**/*"]
+}


### PR DESCRIPTION
## Production symptom

Node 22 apps using facturajs 0.4.2 log bursts of `unhandledRejection` events
while creating AFIP invoices — five in six seconds in the reported case. Every
one carries a raw `AxiosError: read ECONNRESET` with no application frames:

```
unhandledRejection {
  name: 'Error',
  message: 'read ECONNRESET',
  stack: 'Error: read ECONNRESET
    at AxiosError.from (.../axios/dist/node/axios.cjs:1355:24)
    at RedirectableRequest.handleRequestError (.../axios/dist/node/axios.cjs:4026:25)
    ...'
}
```

The invoicing itself succeeds: the same error is also delivered through soap's
callback path, the app retries, every bill gets a CAE. The unhandled rejection
is a *duplicate* surfacing of an error that was already handled.

## Root cause

`soap`'s `HttpClient.request()` reports a transport failure twice — through the
`callback` it was given, and through the promise it returns:

```js
let req = this._request(options);
req.then(onOk, (err) => callback(err));   // marks `req` handled
return req;                               // returned to soap's own callers
```

`req` itself is handled, so it is *not* the floating promise. The leak is one
level up, in `soap/lib/client.js`:

```js
async _invoke(method, args, location, callback, options, extraHeaders) {   // <-- async
    ...
    return this.httpClient.request(location, xml, (err, response, body) => { ... });
}

_defineMethod(method, location) {
    return (args, callback, options, extraHeaders) => {
        this._invoke(method, args, location, (...) => { ... }, options, extraHeaders);
        //  ^ return value discarded
    };
}
```

Because `_invoke` is `async`, `return <promise>` makes the async function's own
promise **adopt** the http client's rejection. `_defineMethod` throws that
promise away, nobody ever attaches a handler, and V8 reports it. This also
explains why the leaked promise looked untraceable: async functions create their
promise internally, so neither `new Promise` nor `.then` instrumentation sees it.

`_invoke` is `async` in soap <= 1.4.x and **not** async in soap 1.8.0 — which is
why the bug is version-dependent. Reproduced deterministically both ways:

| soap | facturajs 0.4.2 | this PR |
|---|---|---|
| 1.4.1 (production) | 19 unhandled rejections / 40 calls | 0 |
| 1.8.0 (current lockfile) | 0 | 0 |

`getSoapClient` currently also only installs `ConfiguredHttpClient` when TLS
request options are present, so `useLegacyTls: false` with no `tlsRequestOptions`
would have been left unprotected either way.

## The fix

`ConfiguredHttpClient.request()` now returns a promise that never rejects. The
error still travels through the `callback`, which is the channel soap actually
reads, so `getLastBillNumber`, `createBill` and `execRemote` keep rejecting with
the original `AxiosError` — no error is swallowed from the caller's perspective.

`requestStream` is deliberately left untouched: in streaming mode the returned
promise is soap's only error channel, and `Client._invoke` does attach a
rejection handler to it.

`ConfiguredHttpClient` is now installed unconditionally, so the guarantee holds
in every configuration.

## Tests

New suite, run with `pnpm test` (builds, type-checks the tests under `strict`,
then `node --test`). It stands up a local HTTPS server that answers with a TCP
RST, and for each of *with* and *without* `tlsRequestOptions` asserts:

- SOAP call reset -> `getLastBillNumber` rejects with `ECONNRESET`, **zero**
  `unhandledRejection` events
- WSDL fetch reset -> same
- nothing failing -> still resolves normally
- **the regression itself**: soap <= 1.4.x's exact shape — an `async` wrapper
  returning the http client's promise, called for side effects only — produces
  zero unhandled rejections while the callback still receives the `AxiosError`
- the promise handed back to soap never rejects

The last two fail on `master` against *any* soap version, so the guarantee does
not silently evaporate if the resolved soap release changes. The end-to-end ones
additionally fail on `master` when soap 1.4.1 is resolved.

## Upstream: already fixed in soap 1.4.2

`Client._invoke` stopped being `async` in **soap 1.4.2** — the patch release
right after the one that was in production. Measured with the facturajs-side
change reverted, 40 calls against a server sending RSTs:

| soap | `_invoke` | unhandled rejections |
|---|---|---|
| 1.4.1 | `async _invoke(...)` | 19 |
| 1.4.2 | `_invoke(...)` | 0 |
| 1.4.3 – 1.8.0 | `_invoke(...)` | 0 |

Both runs used axios 1.18.1, so **axios is not a factor** — axios correctly
rejects the promise it hands out; soap is the one adopting that rejection into
a discarded `async` wrapper. No axios version helps under soap 1.4.1, and none
is needed from 1.4.2 on.

This PR therefore also raises the `soap` floor from `^1.1.11` to `^1.4.2`, so
consumers cannot resolve an affected release. The resolved version is unchanged
(1.8.0); only the floor and the lockfile specifier move.

The facturajs-side change is still worth keeping on top of that floor:

1. soap's `HttpClient.request` still reports errors on two channels while its
   own callers only read one. 1.4.2 fixed a symptom, not the shape.
2. The two version-agnostic regression tests pin the invariant down, so it
   cannot silently regress if soap's internals shift again.

Nothing further is needed upstream, though the tidiest belt-and-braces change
in `node-soap` would be for `HttpClient.request` to keep the promise it hands
back non-rejecting, since it already commits to reporting errors via `callback`.

## Other

- `engines.node` corrected from `>=6.0.0` to `>=20.19.0`. The old value had been
  unachievable for several releases — `soap` 1.8.0 requires Node 20.19+,
  `ntp-time-sync` requires 18+, and the emitted code targets ES2022. This
  documents the real floor rather than changing it; nothing that worked before
  stops working.
- Version bump 0.4.2 -> 0.4.3 + `CHANGELOG.md`
- Public API unchanged
