### PR TITLE
Add pnpm supply-chain policy and GitHub Actions CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+    # Keeps the SHA pins in .github/workflows/ci.yml current. Without this,
+    # pinning actions by SHA means silently running stale action code forever.
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      commit-message:
+          prefix: 'ci'
+
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+      commit-message:
+          prefix: 'deps'
+          prefix-development: 'deps-dev'
+      groups:
+          # One PR for routine bumps instead of one per package, so review
+          # attention goes to the diffs that actually matter.
+          minor-and-patch:
+              update-types:
+                  - minor
+                  - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,47 @@ jobs:
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+            # pnpm 11 itself requires node >= 22.13 (it loads node:sqlite), so
+            # dependencies are installed on 22 and only the compile and the
+            # smoke test are run on the floor version. Consumers are unaffected
+            # by this — they install facturajs with their own package manager.
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: '22'
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile --ignore-scripts
+
             - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   # Must track engines.node in package.json.
                   node-version: '20.19'
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile --ignore-scripts
-            - run: pnpm build
-            - run: pnpm type:test
+            # Invoked directly rather than through `pnpm run`, which would pull
+            # in the pnpm binary again.
+            - run: node ./node_modules/typescript/bin/tsc
+            - run: node ./node_modules/typescript/bin/tsc --project tsconfig.test.json
+
+            # Compiling is not the same as loading: this is what catches a
+            # dependency that stops working on the declared floor.
+            - name: Smoke test the built package
+              run: |
+                  node -e "
+                  const { AfipServices, AfipSoap, Wsfev1 } = require('./dist/index.js');
+                  const svc = new AfipServices({
+                      homo: true,
+                      cacheTokensPath: '/tmp/floor-smoke.json',
+                      tokensExpireInHours: 12,
+                      certContents: 'unused',
+                      privateKeyContents: 'unused',
+                  });
+                  for (const m of ['createBill', 'getLastBillNumber', 'getVatReceiverConditions', 'execRemote']) {
+                      if (typeof svc[m] !== 'function') throw new Error('missing export: ' + m);
+                  }
+                  if (typeof AfipSoap !== 'function' || typeof Wsfev1 !== 'object') {
+                      throw new Error('unexpected index exports');
+                  }
+                  console.log('smoke ok on ' + process.version);
+                  "
 
     audit:
         name: Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ concurrency:
 # class of attack the pnpm settings guard against. Dependabot keeps these
 # current (see .github/dependabot.yml).
 #
-# `--ignore-scripts` on install is deliberate. This package's `prepare` script
-# runs `prettier --write`, so letting it run would silently reformat the tree
-# and make the format check pass no matter what was committed.
+# `--ignore-scripts` on install is deliberate. Nothing here needs a lifecycle
+# script to install — the build lives in `prepack`, and every job that needs
+# dist/ builds it explicitly. Keeping the flag means a script added to the
+# install path later cannot quietly do work that CI is supposed to verify (an
+# earlier `prepare` ran `prettier --write`, which would have made the format
+# check pass no matter what was committed).
 
 jobs:
     format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+    workflow_dispatch:
+
+# Least privilege: nothing here needs to write to the repo.
+permissions:
+    contents: read
+
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
+# Third-party actions are pinned to commit SHAs rather than tags: a tag can be
+# repointed at new code by whoever controls the action's repo, which is the same
+# class of attack the pnpm settings guard against. Dependabot keeps these
+# current (see .github/dependabot.yml).
+#
+# `--ignore-scripts` on install is deliberate. This package's `prepare` script
+# runs `prettier --write`, so letting it run would silently reformat the tree
+# and make the format check pass no matter what was committed.
+
+jobs:
+    format:
+        name: Format
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: '22'
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile --ignore-scripts
+            - run: pnpm format:check
+
+    test:
+        name: Test (node ${{ matrix.node }})
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                # The test runner needs directory globs and native TypeScript
+                # type stripping, both of which land in node 22. See build-floor
+                # for coverage of the oldest version the package itself supports.
+                node: ['22', '24']
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: ${{ matrix.node }}
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile --ignore-scripts
+            # Builds, type-checks the test sources under `strict`, then runs the
+            # suite against dist/.
+            - run: pnpm test
+
+    build-floor:
+        name: Build on engines floor
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  # Must track engines.node in package.json.
+                  node-version: '20.19'
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile --ignore-scripts
+            - run: pnpm build
+            - run: pnpm type:test
+
+    audit:
+        name: Audit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: '22'
+                  cache: pnpm
+            # This install is the supply-chain gate as much as the audit is:
+            # pnpm validates the committed lockfile against the policies in
+            # pnpm-workspace.yaml and exits non-zero if an entry is, for
+            # instance, younger than minimumReleaseAge.
+            - run: pnpm install --frozen-lockfile --ignore-scripts
+            - run: pnpm audit --audit-level high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Repository tooling only — no change to the published package.
   allowlist, store integrity verification and a pinned package manager. CI
   enforces the policy against the committed lockfile, so a pull request that
   bumps a dependency to a freshly published version fails before it merges.
+- Moved the build from `prepare` to `prepack`. It used to run on every
+  `pnpm install`, which rebuilt `dist/` and — because `prepare` also ran
+  `prettier --write` — reformatted the working tree as a side effect of
+  installing. The build now runs only when a tarball is produced: `pnpm pack`,
+  `pnpm publish`, and installs straight from git (verified all three). Formatting
+  is checked in CI instead of being silently applied.
 - Refreshed transitive dependencies within their existing ranges, clearing all
   33 known advisories (`axios` 1.15.0 → 1.18.1, `@xmldom/xmldom` 0.8.12 →
   0.8.13, `form-data` 4.0.5 → 4.0.6). Only the lockfile moved; no declared range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+Repository tooling only — no change to the published package.
+
+- Added GitHub Actions CI: format check, test matrix on Node 22 and 24, a build
+  on the Node 20.19 engines floor, and a dependency audit. Third-party actions
+  are pinned to commit SHAs, kept current by Dependabot.
+- Added pnpm supply-chain policy in `pnpm-workspace.yaml`: a 24h
+  `minimumReleaseAge` cooldown, an explicitly empty `onlyBuiltDependencies`
+  allowlist, store integrity verification and a pinned package manager. CI
+  enforces the policy against the committed lockfile, so a pull request that
+  bumps a dependency to a freshly published version fails before it merges.
+- Refreshed transitive dependencies within their existing ranges, clearing all
+  33 known advisories (`axios` 1.15.0 → 1.18.1, `@xmldom/xmldom` 0.8.12 →
+  0.8.13, `form-data` 4.0.5 → 4.0.6). Only the lockfile moved; no declared range
+  changed.
+
 ## 0.4.3
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Emilio Astarita",
   "licence": "MIT",
   "version": "0.4.3",
-  "packageManager": "pnpm@10.7.0",
+  "packageManager": "pnpm@11.17.0",
   "engines": {
     "node": ">=20.19.0"
   },
@@ -16,6 +16,8 @@
     "prepare": "pnpm prettier && pnpm clean && pnpm build",
     "build": "pnpm exec tsc",
     "type:test": "pnpm exec tsc --project tsconfig.test.json",
+    "format:check": "prettier --check \"{src,test}/**/*.{md,json,ts}\"",
+    "audit": "pnpm audit --audit-level high",
     "test": "pnpm build && pnpm type:test && node --test \"test/**/*.test.ts\"",
     "generate:types": "./scripts/generate-wsdl-types.sh",
     "type:dts": "tsc --emitDeclarationOnly --project tsconfig.build.json"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prettier": "prettier --write \"{src,test}/**/*.{md,json,ts}\"",
     "clean": "rm -rf dist/*",
-    "prepare": "pnpm prettier && pnpm clean && pnpm build",
+    "prepack": "pnpm clean && pnpm build",
     "build": "pnpm exec tsc",
     "type:test": "pnpm exec tsc --project tsconfig.test.json",
     "format:check": "prettier --check \"{src,test}/**/*.{md,json,ts}\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,10 +89,13 @@ packages:
     resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
     engines: {node: '>= 16'}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -111,8 +114,8 @@ packages:
   axios-ntlm@1.4.6:
     resolution: {integrity: sha512-4nR5cbVEBfPMTFkd77FEDpDuaR205JKibmrkaQyNwGcCx0szWNpRZaL0jZyMx4+mVY2PXHjRHuJafv9Oipl0Kg==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -223,8 +226,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -269,6 +272,14 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -514,7 +525,13 @@ snapshots:
 
   '@xmldom/is-dom-node@1.0.1': {}
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
+
+  agent-base@6.0.2(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   ansi-regex@5.0.1: {}
 
@@ -526,22 +543,25 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-ntlm@1.4.6(debug@4.4.3):
+  axios-ntlm@1.4.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      axios: 1.15.0(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       des.js: 1.1.0
       dev-null: 0.1.1
       js-md4: 0.3.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
-  axios@1.15.0(debug@4.4.3):
+  axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -644,16 +664,16 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formidable@3.5.4:
@@ -701,6 +721,17 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
+    dependencies:
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   inherits@2.0.4: {}
 
@@ -781,10 +812,10 @@ snapshots:
 
   soap@1.8.0(supports-color@8.1.1):
     dependencies:
-      axios: 1.15.0(debug@4.4.3)
-      axios-ntlm: 1.4.6(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios-ntlm: 1.4.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       formidable: 3.5.4
       sax: 1.6.0
       whatwg-mimetype: 4.0.0
@@ -852,7 +883,7 @@ snapshots:
   xml-crypto@6.1.2:
     dependencies:
       '@xmldom/is-dom-node': 1.0.1
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       xpath: 0.0.33
 
   xml2js@0.6.2:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,39 @@
+# pnpm settings. Since pnpm 10.16 this file — not .npmrc — is where pnpm's own
+# configuration lives.
+#
+# The threat model here is the npm-ecosystem supply-chain attack: a maintainer
+# account is compromised, a malicious patch version is published, and it is
+# pulled into thousands of builds within hours by lockfile refreshes and
+# `^`-ranged installs, usually executing its payload from a lifecycle script.
+
+# 1. Cooldown. Never resolve a version that was published less than 24h ago.
+#    Compromised releases are typically yanked within hours, so simply waiting
+#    is the single most effective mitigation available. Only affects resolution,
+#    so CI installs (--frozen-lockfile) are unaffected; it slows down `pnpm
+#    update`, which is the point.
+minimumReleaseAge: 1440
+
+# 2. No dependency lifecycle scripts. pnpm 10+ blocks them by default, but the
+#    allowlist is kept here explicitly and empty so that adding a dependency
+#    that wants to run code at install time is a visible, reviewable diff rather
+#    than a silent `pnpm approve-builds` on someone's laptop.
+onlyBuiltDependencies: []
+dangerouslyAllowAllBuilds: false
+
+# 3. Re-check tarball checksums against the lockfile even when serving from the
+#    local store, so a poisoned store cannot quietly feed a bad package.
+verifyStoreIntegrity: true
+
+# 4. Refuse to run scripts against a node_modules that has drifted from the
+#    lockfile — that drift is how a locally installed package survives a
+#    lockfile revert.
+verifyDepsBeforeRun: warn
+
+# 5. Pin pnpm itself. `packageManager` in package.json is only advisory unless
+#    these are on; a mismatched pnpm is just as capable of rewriting the
+#    lockfile as a bad dependency is.
+packageManagerStrict: true
+packageManagerStrictVersion: true
+
+# 6. Peer ranges must be satisfiable rather than quietly patched over.
+strictPeerDependencies: true


### PR DESCRIPTION
Two things: a pnpm supply-chain policy, and GitHub Actions CI. There was no CI
and no `.github/` directory at all before this.

## Supply chain

New `pnpm-workspace.yaml` — since pnpm 10.16 that file, not `.npmrc`, is where
pnpm's own settings live:

| setting | why |
|---|---|
| `minimumReleaseAge: 1440` | never resolve a version published <24h ago |
| `onlyBuiltDependencies: []` | no dependency lifecycle scripts, explicitly and reviewably |
| `dangerouslyAllowAllBuilds: false` | belt and braces on the above |
| `verifyStoreIntegrity: true` | a poisoned local store can't quietly feed a bad tarball |
| `verifyDepsBeforeRun: warn` | catch a `node_modules` that has drifted from the lockfile |
| `packageManagerStrict` + `…StrictVersion` | `packageManager` is advisory without these |
| `strictPeerDependencies: true` | peer ranges must be satisfiable, not patched over |

The threat model is the ordinary npm-ecosystem compromise: maintainer account
taken over, malicious patch version published, pulled into thousands of builds
within hours, payload runs from a lifecycle script. The cooldown is the setting
that actually moves the needle — compromised releases are usually yanked within
hours, so not being first to install is the cheapest real defence.

**The cooldown is enforced on the committed lockfile, not just at resolution
time.** I verified this rather than assuming it: with the policy tightened
artificially, `pnpm install --frozen-lockfile` exits `1` and names the offending
entries:

```
debug@4.4.3 was published at 2025-09-13T…, within the minimumReleaseAge cutoff (…)
…and 25 more
The lockfile contains entries that the active policies reject.
$ echo $?
1
```

So a PR that bumps a dependency to a freshly published version fails CI before
it can merge — including a Dependabot PR.

This needs pnpm 11 (10.7.0 does not know the setting), so `packageManager` moves
to `pnpm@11.17.0`. Lockfile format is unchanged at v9.0.

### Transitive advisories cleared

`pnpm audit` reported **33 findings** on `master`; now **none**. Bumped within
their existing ranges — no declared range changed, `soap` stays at 1.8.0:

- `axios` 1.15.0 → 1.18.1
- `@xmldom/xmldom` 0.8.12 → 0.8.13
- `form-data` 4.0.5 → 4.0.6

## CI

`.github/workflows/ci.yml`, four jobs:

| job | node | what |
|---|---|---|
| `format` | 22 | `prettier --check` |
| `test` | 22, 24 | full suite |
| `build-floor` | 20.19 | build + test typecheck on the `engines` floor |
| `audit` | 22 | `pnpm audit --audit-level high` |

The test matrix starts at **22** because the suite needs directory globs and
native TypeScript type stripping. Verified against real 20.19.5, 22.23.1 and
24.11.1 runtimes — 20 builds and type-checks fine but cannot run `node --test`
on `.ts` files, which is why it gets its own job rather than being dropped or
left to fail.

CI caught one thing on its first run that I had not anticipated: **pnpm 11 itself
requires Node >= 22.13** (it loads `node:sqlite`), so it cannot run on the floor
version at all.

```
##[error]warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

`build-floor` now installs on Node 22, then switches the runtime to 20.19 and
invokes `tsc` directly. Only this repo's tooling needs 22+; consumers install
facturajs with their own package manager, so `engines.node >= 20.19.0` is still
correct. The job also runs a smoke test — compiling on the floor version does not
prove the package *loads* there, so it requires `dist/`, instantiates
`AfipServices` and checks the public exports. That is what would catch a
dependency quietly dropping Node 20 support.

## Build moved from `prepare` to `prepack`

`prepare` runs on every `pnpm install`, so installing dependencies also rebuilt
`dist/` and — because the script chained `prettier --write` — rewrote the working
tree. Formatting your source as a side effect of installing is surprising, and it
was the reason CI needed `--ignore-scripts` to get an honest format check.

`prepack` runs only when a tarball is actually produced. All three paths that
matter were verified, not assumed:

| flow | result |
|---|---|
| `pnpm pack` | prepack ran, tarball has 546 `dist/` entries |
| `pnpm publish` | same lifecycle |
| install from git | `npm i git+file://…#branch` into a scratch project built `dist/`, and `require('facturajs')` resolved |

That last one is the flow that could have regressed — `prepare` is what builds a
package installed straight from a git URL. `prepack` covers it on npm 7+.

Formatting is no longer applied automatically. `pnpm prettier` is still there for
that, and the CI format job checks it.

CI keeps `--ignore-scripts` as defence in depth: nothing needs a lifecycle script
to install now, and the flag stops a future one from quietly doing work the
pipeline is meant to verify.

Actions are **pinned to commit SHAs**, not tags — a tag can be repointed at new
code by whoever controls the action's repo, which is the same class of attack
the pnpm settings guard against. `.github/dependabot.yml` keeps those pins
current and groups routine npm bumps into a single PR.

`permissions: contents: read` at workflow level, plus a `concurrency` group so
superseded runs get cancelled.

## Verified locally

- `pnpm test` 10/10 on Node 22 and 24
- `pnpm build` + `pnpm type:test` on Node 20.19, 22, 24
- `pnpm format:check` clean
- `pnpm audit --audit-level high` clean
- `pnpm install --frozen-lockfile` exits 0; exits 1 under a deliberately violated policy

## CI result

All five jobs green on this PR:

```
OVERALL: success
  success  Format
  success  Test (node 22)          # pass 10
  success  Test (node 24)          # pass 10
  success  Build on engines floor  # smoke ok on v20.19.6
  success  Audit                   # No known vulnerabilities found
```

Every job's install logs `✓ Lockfile passes supply-chain policies (113 entries)`,
so the cooldown gate is live on all of them, not just the audit job.

No change to the published package — `files` is `["dist/"]`, and no source or
declared dependency range was touched.
